### PR TITLE
Type declaration for optional parameters

### DIFF
--- a/src/constraint.ts
+++ b/src/constraint.ts
@@ -82,8 +82,8 @@ namespace kiwi {
         constructor(
             expression: Expression|Variable,
             operator: Operator,
-            rhs: Expression|Variable|number,
-            strength: number = Strength.required) {
+            rhs?: Expression|Variable|number,
+            strength?: number = Strength.required) {
             this._operator = operator;
             this._strength = Strength.clip(strength);
             if ((rhs === undefined) && (expression instanceof Expression)) {


### PR DESCRIPTION
Optional parameters can be declared in the type using `?`.